### PR TITLE
Test improvements for clarinet 0.31.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ MultiSafe is written in Clarity and therefore requires you to install Clarinet l
 $ clarinet --version
 ```
 
-Please make sure you have Clarinet version 0.31 or higher installed.
+Please make sure you have Clarinet version 0.31.1 or higher installed.
 
 ### Download MultiSafe  
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ MultiSafe is written in Clarity and therefore requires you to install Clarinet l
 $ clarinet --version
 ```
 
+Please make sure you have Clarinet version 0.31 or higher installed.
+
 ### Download MultiSafe  
 
 1. Clone the repo: 

--- a/tests/safe_test.ts
+++ b/tests/safe_test.ts
@@ -1,5 +1,5 @@
-import { Clarinet, Tx, Chain, Account, types, green } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
-import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+import { Clarinet, Tx, Chain, Account, types, green } from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.125.0/testing/asserts.ts';
 
 const FT_NONE = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ft-none");
 const NFT_NONE = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-none");

--- a/tests/safe_test.ts
+++ b/tests/safe_test.ts
@@ -132,10 +132,10 @@ const getTransaction = (CHAIN: Chain, txId: number, txSender: string) => {
 type TestFn = (
     CHAIN: Chain,
     WALLETS: string[],
-    DEPLOYER: string,
+    DEPLOYER?: string,
 ) => void
 
-const testSetup: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testSetup: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // send some stx to the safe contract
     CHAIN.mineBlock([
         Tx.transferSTX(
@@ -149,7 +149,7 @@ const testSetup: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) =>
     assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 50000000);
 }
 
-const testSafeOnly: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testSafeOnly: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     let block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -181,7 +181,7 @@ const testSafeOnly: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string)
     assertEquals(block.receipts[0].result.expectErr(), "u100");
 }
 
-const testOnlyOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testOnlyOwner: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     let resp = addOwner(CHAIN, "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND", WALLETS[3]);
     assertEquals(resp.expectErr(), "u130");
 
@@ -189,7 +189,7 @@ const testOnlyOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string
     assertEquals(resp.expectErr(), "u130");
 }
 
-const testAddNewOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testAddNewOwner: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Check current owners. Should be 3.
     let owners = getOwners(CHAIN, WALLETS[0]);
     assertEquals(owners.length, 3);
@@ -245,7 +245,7 @@ const testAddNewOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: stri
     assertEquals(nonce, "u1");
 }
 
-const testSetThreshold: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testSetThreshold: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Check current value. should be 2.
     let threshold = getThreshold(CHAIN, WALLETS[0]);
     assertEquals(threshold, "u2");
@@ -263,7 +263,7 @@ const testSetThreshold: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: str
     assertEquals(threshold, "u3");
 }
 
-const testRemoveOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testRemoveOwner: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Start a new transaction to remove an owner.
     let resp = removeOwner(CHAIN, WALLETS[0], WALLETS[3]);
     assertEquals(resp.expectOk(), "u2");
@@ -291,7 +291,7 @@ const testRemoveOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: stri
     assertEquals(owners.length, 3);
 }
 
-const testSpendStx: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testSpendStx: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Start a new transaction to send STX from the safe to another account
     let resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
     assertEquals(resp.expectOk(), "u3");
@@ -309,7 +309,7 @@ const testSpendStx: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string)
     assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 0);
 }
 
-const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER?: string) => {
     // We have an imaginary vault contract and owner of the contract is the safe contract
     // We want to update `token-per-cycle` by calling an owner only function `set-token-per-cycle`
 
@@ -319,7 +319,7 @@ const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPL
             "vault",
             "get-token-per-cycle",
             [],
-            DEPLOYER
+            DEPLOYER!
         ),
     ]);
     assertEquals(block.receipts[0].result, "u100");
@@ -330,7 +330,7 @@ const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPL
             "vault",
             "set-token-per-cycle",
             [types.uint(500)],
-            DEPLOYER
+            DEPLOYER!
         ),
     ]);
     assertEquals(block.receipts[0].result.expectErr(), "u900");
@@ -394,13 +394,13 @@ const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPL
             "vault",
             "get-token-per-cycle",
             [],
-            DEPLOYER
+            DEPLOYER!
         ),
     ]);
     assertEquals(block.receipts[0].result, "u1200");
 }
 
-const testListTransactionsByIds: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testListTransactionsByIds: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     let block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -413,7 +413,7 @@ const testListTransactionsByIds: TestFn = (CHAIN: Chain, WALLETS: string[], DEPL
     assertEquals(block.receipts[0].result.expectList().length, 5);
 }
 
-const testGetVersion: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testGetVersion: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     let block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -426,7 +426,7 @@ const testGetVersion: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: strin
     assertEquals(block.receipts[0].result, '"0.0.2.alpha"');
 }
 
-const testGetInfo: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testGetInfo: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     let block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -443,7 +443,7 @@ const testGetInfo: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) 
     assertEquals(json.nonce !== undefined, true);
 }
 
-const testRevoke: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testRevoke: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Tx not exists.
     let resp = revoke(CHAIN, 10, WALLETS[2]);
     assertEquals(resp.expectErr(), 'u140');
@@ -469,7 +469,7 @@ const testRevoke: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) =
     assertEquals(JSON.parse(JSON.stringify(tx)).confirmations, '[]');
 }
 
-const testSetThresholdOverflowProtection: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testSetThresholdOverflowProtection: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Start a transaction to set threshold.
     let resp = setThreshold(CHAIN, 21, WALLETS[1]);
     assertEquals(resp.expectOk(), "u6");
@@ -482,7 +482,7 @@ const testSetThresholdOverflowProtection: TestFn = (CHAIN: Chain, WALLETS: strin
     assertEquals(resp.expectErr(), "u220");
 }
 
-const testSetThresholdOwnerCountProtection: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testSetThresholdOwnerCountProtection: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Start a transaction to set threshold.
     let resp = setThreshold(CHAIN, 4, WALLETS[1]);
     assertEquals(resp.expectOk(), "u7");
@@ -495,7 +495,7 @@ const testSetThresholdOwnerCountProtection: TestFn = (CHAIN: Chain, WALLETS: str
     assertEquals(resp.expectErr(), "u230");
 }
 
-const testRemoveOwnerThresholdProtection: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+const testRemoveOwnerThresholdProtection: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
     // Start a new transaction to remove an owner.
     let resp = removeOwner(CHAIN, WALLETS[3], WALLETS[3]);
     assertEquals(resp.expectOk(), "u8");
@@ -515,20 +515,20 @@ Clarinet.test({
         const WALLETS = [...Array(9).keys()].map(x => accounts.get(`wallet_${x + 1}`)!.address);
         const DEPLOYER = accounts.get('deployer')!.address
 
-        testSetup(chain, WALLETS, DEPLOYER);
-        testSafeOnly(chain, WALLETS, DEPLOYER);
-        testOnlyOwner(chain, WALLETS, DEPLOYER);
-        testAddNewOwner(chain, WALLETS, DEPLOYER);
-        testSetThreshold(chain, WALLETS, DEPLOYER);
-        testRemoveOwner(chain, WALLETS, DEPLOYER);
-        testSpendStx(chain, WALLETS, DEPLOYER);
+        testSetup(chain, WALLETS);
+        testSafeOnly(chain, WALLETS);
+        testOnlyOwner(chain, WALLETS);
+        testAddNewOwner(chain, WALLETS);
+        testSetThreshold(chain, WALLETS);
+        testRemoveOwner(chain, WALLETS);
+        testSpendStx(chain, WALLETS);
         testVaultOwnershipExample(chain, WALLETS, DEPLOYER);
-        testListTransactionsByIds(chain, WALLETS, DEPLOYER);
-        testGetVersion(chain, WALLETS, DEPLOYER);
-        testGetInfo(chain, WALLETS, DEPLOYER);
-        testRevoke(chain, WALLETS, DEPLOYER);
-        testSetThresholdOverflowProtection(chain, WALLETS, DEPLOYER);
-        testSetThresholdOwnerCountProtection(chain, WALLETS, DEPLOYER);
-        testRemoveOwnerThresholdProtection(chain, WALLETS, DEPLOYER);
+        testListTransactionsByIds(chain, WALLETS);
+        testGetVersion(chain, WALLETS);
+        testGetInfo(chain, WALLETS);
+        testRevoke(chain, WALLETS);
+        testSetThresholdOverflowProtection(chain, WALLETS);
+        testSetThresholdOwnerCountProtection(chain, WALLETS);
+        testRemoveOwnerThresholdProtection(chain, WALLETS);
     },
 });

--- a/tests/safe_test.ts
+++ b/tests/safe_test.ts
@@ -1,4 +1,4 @@
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types, green } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 const FT_NONE = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ft-none");
@@ -135,400 +135,379 @@ type TestFn = (
     DEPLOYER?: string,
 ) => void
 
-const testSetup: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // send some stx to the safe contract
-    CHAIN.mineBlock([
-        Tx.transferSTX(
-            50000000,
-            "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe",
-            "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
-        ),
-    ]);
+const TESTS: Record<string, TestFn> = {
+    "testSetup": (CHAIN: Chain, WALLETS: string[]) => {
+        // send some stx to the safe contract
+        CHAIN.mineBlock([
+            Tx.transferSTX(
+                50000000,
+                "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe",
+                "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+            ),
+        ]);
 
-    const assetMap = CHAIN.getAssetsMaps();
-    assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 50000000);
+        const assetMap = CHAIN.getAssetsMaps();
+        assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 50000000);
+    },
+    "testSafeOnly": (CHAIN: Chain, WALLETS: string[]) => {
+        let block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "add-owner",
+                [types.principal(WALLETS[3])],
+                WALLETS[0]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectErr(), "u100");
+
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "remove-owner",
+                [types.principal(WALLETS[2])],
+                WALLETS[1]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectErr(), "u100");
+
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "set-threshold",
+                [types.uint(1)],
+                WALLETS[2]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectErr(), "u100");
+    },
+    "testOnlyOwner": (CHAIN: Chain, WALLETS: string[]) => {
+        let resp = addOwner(CHAIN, "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND", WALLETS[3]);
+        assertEquals(resp.expectErr(), "u130");
+
+        resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[3]);
+        assertEquals(resp.expectErr(), "u130");
+    },
+    "testAddNewOwner": (CHAIN: Chain, WALLETS: string[]) => {
+        // Check current owners. Should be 3.
+        let owners = getOwners(CHAIN, WALLETS[0]);
+        assertEquals(owners.length, 3);
+        assertEquals(owners[0], WALLETS[0]);
+        assertEquals(owners[1], WALLETS[1]);
+        assertEquals(owners[2], WALLETS[2]);
+
+        // Start a new transaction to add a new owner.
+        let resp = addOwner(CHAIN, WALLETS[3], WALLETS[0]);
+        assertEquals(resp.expectOk(), "u0");
+
+        // The new transaction should be available in the transacions mapping.
+        let tx: any = getTransaction(CHAIN, 0, WALLETS[0]);
+        let confirmations = tx.confirmations.expectList()
+
+        assertEquals(tx.id, "u0");
+        assertEquals(tx.confirmed, "false");
+        assertEquals(confirmations.length, 1);
+        assertEquals(confirmations[0], WALLETS[0]);
+
+        // The user already confirmed transaction by submitting it. Should revert.
+        resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[0]);
+        assertEquals(resp.expectErr(), "u150");
+
+        // Executor should be passed properly. Should revert.
+        resp = confirm(CHAIN, 0, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
+        assertEquals(resp.expectErr(), "u160");
+
+        // Owner 2 confirms.
+        resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[1]);
+        assertEquals(resp.expectOk(), "true");
+
+        // The transaction already confirmed. Should revert
+        resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[2]);
+        assertEquals(resp.expectErr(), "u180");
+
+        // The transaction confirmed by sufficient number of owners.
+        tx = getTransaction(CHAIN, 0, WALLETS[0]);
+        confirmations = tx.confirmations.expectList();
+
+        assertEquals(tx.confirmed, "true");
+        assertEquals(confirmations.length, 2);
+        assertEquals(confirmations[0], WALLETS[0]);
+        assertEquals(confirmations[1], WALLETS[1]);
+
+        // New owner should be added. should be 4.
+        owners = getOwners(CHAIN, WALLETS[0]);
+        assertEquals(owners.length, 4);
+        assertEquals(owners[3], WALLETS[3]);
+
+        // Nonce should be incremented.
+        const nonce = getNonce(CHAIN, WALLETS[0]);
+        assertEquals(nonce, "u1");
+    },
+    "testSetThreshold": (CHAIN: Chain, WALLETS: string[]) => {
+        // Check current value. should be 2.
+        let threshold = getThreshold(CHAIN, WALLETS[0]);
+        assertEquals(threshold, "u2");
+
+        // Start a transaction to update minimum confirmation requirement.
+        let resp = setThreshold(CHAIN, 3, WALLETS[0]);
+        assertEquals(resp.expectOk(), "u1");
+
+        // // Owner 2 confirms. Confirmed.
+        resp = confirm(CHAIN, 1, THRESHOLD_EXECUTOR, WALLETS[1]);
+        assertEquals(resp.expectOk(), "true");
+
+        // Minimum confirmation requirement should be updated as 3.
+        threshold = getThreshold(CHAIN, WALLETS[0]);
+        assertEquals(threshold, "u3");
+    },
+    "testRemoveOwner": (CHAIN: Chain, WALLETS: string[]) => {
+        // Start a new transaction to remove an owner.
+        let resp = removeOwner(CHAIN, WALLETS[0], WALLETS[3]);
+        assertEquals(resp.expectOk(), "u2");
+
+        // Owner 2 confirms.
+        resp = confirm(CHAIN, 2, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
+        assertEquals(resp.expectOk(), "false");
+
+        // Owner 3 confirms.
+        resp = confirm(CHAIN, 2, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
+        assertEquals(resp.expectOk(), "true");
+
+        // Confirmed.
+        let tx: any = getTransaction(CHAIN, 2, WALLETS[0]);
+        let confirmations = tx.confirmations.expectList()
+
+        assertEquals(tx.confirmed, "true");
+        assertEquals(confirmations.length, 3);
+        assertEquals(confirmations[0], WALLETS[3]);
+        assertEquals(confirmations[1], WALLETS[1]);
+        assertEquals(confirmations[2], WALLETS[2]);
+
+        // Owner should be removed. Now we should have 3 owners.
+        let owners = getOwners(CHAIN, WALLETS[0]);
+        assertEquals(owners.length, 3);
+    },
+    "testSpendStx": (CHAIN: Chain, WALLETS: string[]) => {
+        // Start a new transaction to send STX from the safe to another account
+        let resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
+        assertEquals(resp.expectOk(), "u3");
+
+        // Owner 2 confirms.
+        resp = confirm(CHAIN, 3, TRANSFER_STX_EXECUTOR, WALLETS[2]);
+        assertEquals(resp.expectOk(), "false");
+
+        // Owner 3 confirms.
+        resp = confirm(CHAIN, 3, TRANSFER_STX_EXECUTOR, WALLETS[3]);
+        assertEquals(resp.expectOk(), "true");
+
+        // Confirmed. STX balance of the safe should be 0.
+        const assetMap = CHAIN.getAssetsMaps();
+        assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 0);
+    },
+    "testVaultOwnershipExample": (CHAIN: Chain, WALLETS: string[], DEPLOYER?: string) => {
+        // We have an imaginary vault contract and owner of the contract is the safe contract
+        // We want to update `token-per-cycle` by calling an owner only function `set-token-per-cycle`
+
+        // Default token per cycle is u100
+        let block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "vault",
+                "get-token-per-cycle",
+                [],
+                DEPLOYER!
+            ),
+        ]);
+        assertEquals(block.receipts[0].result, "u100");
+
+        // The vault contract can't be updated directly by a user because it is owned by the safe contract
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "vault",
+                "set-token-per-cycle",
+                [types.uint(500)],
+                DEPLOYER!
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectErr(), "u900");
+
+        // Start transaction to update `token-per-cycle`
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "submit",
+                [
+                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
+                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
+                    FT_NONE,
+                    NFT_NONE,
+                    types.some(types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")),
+                    types.some(types.uint(1200)),
+                    types.none()
+                ],
+                WALLETS[1]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectOk(), "u4");
+
+        // Owner 2 confirms.
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "confirm",
+                [
+                    types.uint(4),
+                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
+                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
+                    FT_NONE,
+                    NFT_NONE,
+                ],
+                WALLETS[2]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectOk(), "false");
+
+        //  Owner 3 confirms.
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "confirm",
+                [
+                    types.uint(4),
+                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
+                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
+                    FT_NONE,
+                    NFT_NONE,
+                ],
+                WALLETS[3]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectOk(), "true");
+
+        // `token-per-cycle` should be updated
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "vault",
+                "get-token-per-cycle",
+                [],
+                DEPLOYER!
+            ),
+        ]);
+        assertEquals(block.receipts[0].result, "u1200");
+    },
+    "testListTransactionsByIds": (CHAIN: Chain, WALLETS: string[]) => {
+        let block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "get-transactions",
+                [types.list([types.uint(0), types.uint(1), types.uint(2), types.uint(3), types.uint(4)])],
+                WALLETS[0]
+            ),
+        ]);
+
+        assertEquals(block.receipts[0].result.expectList().length, 5);
+    },
+    "testGetVersion": (CHAIN: Chain, WALLETS: string[]) => {
+        let block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "get-version",
+                [],
+                WALLETS[0]
+            ),
+        ]);
+
+        assertEquals(block.receipts[0].result, '"0.0.2.alpha"');
+    },
+    "testGetInfo": (CHAIN: Chain, WALLETS: string[]) => {
+        let block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "get-info",
+                [],
+                WALLETS[0]
+            ),
+        ]);
+
+        const json = JSON.parse(JSON.stringify(block.receipts[0].result.expectTuple()));
+        assertEquals(json.version !== undefined, true);
+        assertEquals(json.owners !== undefined, true);
+        assertEquals(json["threshold"] !== undefined, true);
+        assertEquals(json.nonce !== undefined, true);
+    },
+    "testRevoke": (CHAIN: Chain, WALLETS: string[]) => {
+        // Tx not exists.
+        let resp = revoke(CHAIN, 10, WALLETS[2]);
+        assertEquals(resp.expectErr(), 'u140');
+
+        // Tx already confirmed.
+        resp = revoke(CHAIN, 4, WALLETS[2]);
+        assertEquals(resp.expectErr(), 'u180');
+
+        // Start a new tx.
+        resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
+        assertEquals(resp.expectOk(), "u5");
+
+        // Should reject becuase the owner hasn't confirmed the tx.
+        resp = revoke(CHAIN, 5, WALLETS[2]);
+        assertEquals(resp.expectErr(), 'u190');
+
+        // Should revoke.
+        resp = revoke(CHAIN, 5, WALLETS[1]);
+        assertEquals(resp.expectOk(), 'true');
+
+        // Confirmation should be removed.
+        const tx = getTransaction(CHAIN, 5, WALLETS[0]);
+        assertEquals(JSON.parse(JSON.stringify(tx)).confirmations, '[]');
+    },
+    "testSetThresholdOverflowProtection": (CHAIN: Chain, WALLETS: string[]) => {
+        // Start a transaction to set threshold.
+        let resp = setThreshold(CHAIN, 21, WALLETS[1]);
+        assertEquals(resp.expectOk(), "u6");
+
+        // Owner 2 confirms.
+        resp = confirm(CHAIN, 6, THRESHOLD_EXECUTOR, WALLETS[2]);
+
+        // Owner 3 confirms but reverted.
+        resp = confirm(CHAIN, 6, THRESHOLD_EXECUTOR, WALLETS[3]);
+        assertEquals(resp.expectErr(), "u220");
+    },
+    "testSetThresholdOwnerCountProtection": (CHAIN: Chain, WALLETS: string[]) => {
+        // Start a transaction to set threshold.
+        let resp = setThreshold(CHAIN, 4, WALLETS[1]);
+        assertEquals(resp.expectOk(), "u7");
+
+        // Owner 2 confirms.
+        resp = confirm(CHAIN, 7, THRESHOLD_EXECUTOR, WALLETS[2]);
+
+        // Owner 3 confirms but reverted.
+        resp = confirm(CHAIN, 7, THRESHOLD_EXECUTOR, WALLETS[3]);
+        assertEquals(resp.expectErr(), "u230");
+    },
+    "testRemoveOwnerThresholdProtection": (CHAIN: Chain, WALLETS: string[]) => {
+        // Start a new transaction to remove an owner.
+        let resp = removeOwner(CHAIN, WALLETS[3], WALLETS[3]);
+        assertEquals(resp.expectOk(), "u8");
+
+        // Owner 2 confirms.
+        resp = confirm(CHAIN, 8, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
+        assertEquals(resp.expectOk(), "false");
+
+        // Owner 3 confirms but reverted.
+        resp = confirm(CHAIN, 8, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
+        assertEquals(resp.expectErr(), "u230");
+    }
 }
 
-const testSafeOnly: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    let block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "add-owner",
-            [types.principal(WALLETS[3])],
-            WALLETS[0]
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectErr(), "u100");
 
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "remove-owner",
-            [types.principal(WALLETS[2])],
-            WALLETS[1]
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectErr(), "u100");
-
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "set-threshold",
-            [types.uint(1)],
-            WALLETS[2]
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectErr(), "u100");
-}
-
-const testOnlyOwner: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    let resp = addOwner(CHAIN, "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND", WALLETS[3]);
-    assertEquals(resp.expectErr(), "u130");
-
-    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[3]);
-    assertEquals(resp.expectErr(), "u130");
-}
-
-const testAddNewOwner: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Check current owners. Should be 3.
-    let owners = getOwners(CHAIN, WALLETS[0]);
-    assertEquals(owners.length, 3);
-    assertEquals(owners[0], WALLETS[0]);
-    assertEquals(owners[1], WALLETS[1]);
-    assertEquals(owners[2], WALLETS[2]);
-
-    // Start a new transaction to add a new owner.
-    let resp = addOwner(CHAIN, WALLETS[3], WALLETS[0]);
-    assertEquals(resp.expectOk(), "u0");
-
-    // The new transaction should be available in the transacions mapping.
-    let tx: any = getTransaction(CHAIN, 0, WALLETS[0]);
-    let confirmations = tx.confirmations.expectList()
-
-    assertEquals(tx.id, "u0");
-    assertEquals(tx.confirmed, "false");
-    assertEquals(confirmations.length, 1);
-    assertEquals(confirmations[0], WALLETS[0]);
-
-    // The user already confirmed transaction by submitting it. Should revert.
-    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[0]);
-    assertEquals(resp.expectErr(), "u150");
-
-    // Executor should be passed properly. Should revert.
-    resp = confirm(CHAIN, 0, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
-    assertEquals(resp.expectErr(), "u160");
-
-    // Owner 2 confirms.
-    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[1]);
-    assertEquals(resp.expectOk(), "true");
-
-    // The transaction already confirmed. Should revert
-    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[2]);
-    assertEquals(resp.expectErr(), "u180");
-
-    // The transaction confirmed by sufficient number of owners.
-    tx = getTransaction(CHAIN, 0, WALLETS[0]);
-    confirmations = tx.confirmations.expectList();
-
-    assertEquals(tx.confirmed, "true");
-    assertEquals(confirmations.length, 2);
-    assertEquals(confirmations[0], WALLETS[0]);
-    assertEquals(confirmations[1], WALLETS[1]);
-
-    // New owner should be added. should be 4.
-    owners = getOwners(CHAIN, WALLETS[0]);
-    assertEquals(owners.length, 4);
-    assertEquals(owners[3], WALLETS[3]);
-
-    // Nonce should be incremented.
-    const nonce = getNonce(CHAIN, WALLETS[0]);
-    assertEquals(nonce, "u1");
-}
-
-const testSetThreshold: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Check current value. should be 2.
-    let threshold = getThreshold(CHAIN, WALLETS[0]);
-    assertEquals(threshold, "u2");
-
-    // Start a transaction to update minimum confirmation requirement.
-    let resp = setThreshold(CHAIN, 3, WALLETS[0]);
-    assertEquals(resp.expectOk(), "u1");
-
-    // // Owner 2 confirms. Confirmed.
-    resp = confirm(CHAIN, 1, THRESHOLD_EXECUTOR, WALLETS[1]);
-    assertEquals(resp.expectOk(), "true");
-
-    // Minimum confirmation requirement should be updated as 3.
-    threshold = getThreshold(CHAIN, WALLETS[0]);
-    assertEquals(threshold, "u3");
-}
-
-const testRemoveOwner: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Start a new transaction to remove an owner.
-    let resp = removeOwner(CHAIN, WALLETS[0], WALLETS[3]);
-    assertEquals(resp.expectOk(), "u2");
-
-    // Owner 2 confirms.
-    resp = confirm(CHAIN, 2, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
-    assertEquals(resp.expectOk(), "false");
-
-    // Owner 3 confirms.
-    resp = confirm(CHAIN, 2, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
-    assertEquals(resp.expectOk(), "true");
-
-    // Confirmed.
-    let tx: any = getTransaction(CHAIN, 2, WALLETS[0]);
-    let confirmations = tx.confirmations.expectList()
-
-    assertEquals(tx.confirmed, "true");
-    assertEquals(confirmations.length, 3);
-    assertEquals(confirmations[0], WALLETS[3]);
-    assertEquals(confirmations[1], WALLETS[1]);
-    assertEquals(confirmations[2], WALLETS[2]);
-
-    // Owner should be removed. Now we should have 3 owners.
-    let owners = getOwners(CHAIN, WALLETS[0]);
-    assertEquals(owners.length, 3);
-}
-
-const testSpendStx: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Start a new transaction to send STX from the safe to another account
-    let resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
-    assertEquals(resp.expectOk(), "u3");
-
-    // Owner 2 confirms.
-    resp = confirm(CHAIN, 3, TRANSFER_STX_EXECUTOR, WALLETS[2]);
-    assertEquals(resp.expectOk(), "false");
-
-    // Owner 3 confirms.
-    resp = confirm(CHAIN, 3, TRANSFER_STX_EXECUTOR, WALLETS[3]);
-    assertEquals(resp.expectOk(), "true");
-
-    // Confirmed. STX balance of the safe should be 0.
-    const assetMap = CHAIN.getAssetsMaps();
-    assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 0);
-}
-
-const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER?: string) => {
-    // We have an imaginary vault contract and owner of the contract is the safe contract
-    // We want to update `token-per-cycle` by calling an owner only function `set-token-per-cycle`
-
-    // Default token per cycle is u100
-    let block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "vault",
-            "get-token-per-cycle",
-            [],
-            DEPLOYER!
-        ),
-    ]);
-    assertEquals(block.receipts[0].result, "u100");
-
-    // The vault contract can't be updated directly by a user because it is owned by the safe contract
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "vault",
-            "set-token-per-cycle",
-            [types.uint(500)],
-            DEPLOYER!
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectErr(), "u900");
-
-    // Start transaction to update `token-per-cycle`
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "submit",
-            [
-                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
-                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
-                FT_NONE,
-                NFT_NONE,
-                types.some(types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")),
-                types.some(types.uint(1200)),
-                types.none()
-            ],
-            WALLETS[1]
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectOk(), "u4");
-
-    // Owner 2 confirms.
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "confirm",
-            [
-                types.uint(4),
-                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
-                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
-                FT_NONE,
-                NFT_NONE,
-            ],
-            WALLETS[2]
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectOk(), "false");
-
-    //  Owner 3 confirms.
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "confirm",
-            [
-                types.uint(4),
-                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
-                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
-                FT_NONE,
-                NFT_NONE,
-            ],
-            WALLETS[3]
-        ),
-    ]);
-    assertEquals(block.receipts[0].result.expectOk(), "true");
-
-    // `token-per-cycle` should be updated
-    block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "vault",
-            "get-token-per-cycle",
-            [],
-            DEPLOYER!
-        ),
-    ]);
-    assertEquals(block.receipts[0].result, "u1200");
-}
-
-const testListTransactionsByIds: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    let block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "get-transactions",
-            [types.list([types.uint(0), types.uint(1), types.uint(2), types.uint(3), types.uint(4)])],
-            WALLETS[0]
-        ),
-    ]);
-
-    assertEquals(block.receipts[0].result.expectList().length, 5);
-}
-
-const testGetVersion: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    let block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "get-version",
-            [],
-            WALLETS[0]
-        ),
-    ]);
-
-    assertEquals(block.receipts[0].result, '"0.0.2.alpha"');
-}
-
-const testGetInfo: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    let block = CHAIN.mineBlock([
-        Tx.contractCall(
-            "safe",
-            "get-info",
-            [],
-            WALLETS[0]
-        ),
-    ]);
-
-    const json = JSON.parse(JSON.stringify(block.receipts[0].result.expectTuple()));
-    assertEquals(json.version !== undefined, true);
-    assertEquals(json.owners !== undefined, true);
-    assertEquals(json["threshold"] !== undefined, true);
-    assertEquals(json.nonce !== undefined, true);
-}
-
-const testRevoke: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Tx not exists.
-    let resp = revoke(CHAIN, 10, WALLETS[2]);
-    assertEquals(resp.expectErr(), 'u140');
-
-    // Tx already confirmed.
-    resp = revoke(CHAIN, 4, WALLETS[2]);
-    assertEquals(resp.expectErr(), 'u180');
-
-    // Start a new tx.
-    resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
-    assertEquals(resp.expectOk(), "u5");
-
-    // Should reject becuase the owner hasn't confirmed the tx.
-    resp = revoke(CHAIN, 5, WALLETS[2]);
-    assertEquals(resp.expectErr(), 'u190');
-
-    // Should revoke.
-    resp = revoke(CHAIN, 5, WALLETS[1]);
-    assertEquals(resp.expectOk(), 'true');
-
-    // Confirmation should be removed.
-    const tx = getTransaction(CHAIN, 5, WALLETS[0]);
-    assertEquals(JSON.parse(JSON.stringify(tx)).confirmations, '[]');
-}
-
-const testSetThresholdOverflowProtection: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Start a transaction to set threshold.
-    let resp = setThreshold(CHAIN, 21, WALLETS[1]);
-    assertEquals(resp.expectOk(), "u6");
-
-    // Owner 2 confirms.
-    resp = confirm(CHAIN, 6, THRESHOLD_EXECUTOR, WALLETS[2]);
-
-    // Owner 3 confirms but reverted.
-    resp = confirm(CHAIN, 6, THRESHOLD_EXECUTOR, WALLETS[3]);
-    assertEquals(resp.expectErr(), "u220");
-}
-
-const testSetThresholdOwnerCountProtection: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Start a transaction to set threshold.
-    let resp = setThreshold(CHAIN, 4, WALLETS[1]);
-    assertEquals(resp.expectOk(), "u7");
-
-    // Owner 2 confirms.
-    resp = confirm(CHAIN, 7, THRESHOLD_EXECUTOR, WALLETS[2]);
-
-    // Owner 3 confirms but reverted.
-    resp = confirm(CHAIN, 7, THRESHOLD_EXECUTOR, WALLETS[3]);
-    assertEquals(resp.expectErr(), "u230");
-}
-
-const testRemoveOwnerThresholdProtection: TestFn = (CHAIN: Chain, WALLETS: string[]) => {
-    // Start a new transaction to remove an owner.
-    let resp = removeOwner(CHAIN, WALLETS[3], WALLETS[3]);
-    assertEquals(resp.expectOk(), "u8");
-
-    // Owner 2 confirms.
-    resp = confirm(CHAIN, 8, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
-    assertEquals(resp.expectOk(), "false");
-
-    // Owner 3 confirms but reverted.
-    resp = confirm(CHAIN, 8, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
-    assertEquals(resp.expectErr(), "u230");
-}
 
 Clarinet.test({
     name: "MultiSafe Tests",
     async fn(chain: Chain, accounts: Map<string, Account>) {
         const WALLETS = [...Array(9).keys()].map(x => accounts.get(`wallet_${x + 1}`)!.address);
-        const DEPLOYER = accounts.get('deployer')!.address
+        const DEPLOYER = accounts.get('deployer')!.address;
 
-        testSetup(chain, WALLETS);
-        testSafeOnly(chain, WALLETS);
-        testOnlyOwner(chain, WALLETS);
-        testAddNewOwner(chain, WALLETS);
-        testSetThreshold(chain, WALLETS);
-        testRemoveOwner(chain, WALLETS);
-        testSpendStx(chain, WALLETS);
-        testVaultOwnershipExample(chain, WALLETS, DEPLOYER);
-        testListTransactionsByIds(chain, WALLETS);
-        testGetVersion(chain, WALLETS);
-        testGetInfo(chain, WALLETS);
-        testRevoke(chain, WALLETS);
-        testSetThresholdOverflowProtection(chain, WALLETS);
-        testSetThresholdOwnerCountProtection(chain, WALLETS);
-        testRemoveOwnerThresholdProtection(chain, WALLETS);
+        for (let t of Object.keys(TESTS)) {
+            TESTS[t](chain, WALLETS, DEPLOYER);
+            console.log(`${t} ${green('ok')}`);
+        }
     },
 });

--- a/tests/safe_test.ts
+++ b/tests/safe_test.ts
@@ -1,11 +1,6 @@
 import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
-
-let CHAIN: Chain;
-let WALLETS: string[] = [];
-let DEPLOYER: string = "";
-
 const FT_NONE = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ft-none");
 const NFT_NONE = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-none");
 
@@ -15,7 +10,9 @@ const REMOVE_OWNER_EXECUTOR = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJ
 const THRESHOLD_EXECUTOR = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-threshold");
 const TRANSFER_STX_EXECUTOR = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.transfer-stx");
 
-const submit = (executor: any, paramP: string | null, paramU: number | null, txSender: string) => {
+/* Test helpers */
+
+const submit = (CHAIN: Chain, executor: any, paramP: string | null, paramU: number | null, txSender: string) => {
     return CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -34,23 +31,23 @@ const submit = (executor: any, paramP: string | null, paramU: number | null, txS
     ]).receipts[0].result;
 }
 
-const addOwner = (newOwner: string, txSender: string) => {
-    return submit(ADD_OWNER_EXECUTOR, newOwner, null, txSender);
+const addOwner = (CHAIN: Chain, newOwner: string, txSender: string) => {
+    return submit(CHAIN, ADD_OWNER_EXECUTOR, newOwner, null, txSender);
 }
 
-const setThreshold = (threshold: number, txSender: string) => {
-    return submit(THRESHOLD_EXECUTOR, null, threshold, txSender);
+const setThreshold = (CHAIN: Chain, threshold: number, txSender: string) => {
+    return submit(CHAIN, THRESHOLD_EXECUTOR, null, threshold, txSender);
 }
 
-const removeOwner = (owner: string, txSender: string) => {
-    return submit(REMOVE_OWNER_EXECUTOR, owner, null, txSender);
+const removeOwner = (CHAIN: Chain, owner: string, txSender: string) => {
+    return submit(CHAIN, REMOVE_OWNER_EXECUTOR, owner, null, txSender);
 }
 
-const transferStx = (recipient: string, amount: number, txSender: string) => {
-    return submit(TRANSFER_STX_EXECUTOR, recipient, amount, txSender);
+const transferStx = (CHAIN: Chain, recipient: string, amount: number, txSender: string) => {
+    return submit(CHAIN, TRANSFER_STX_EXECUTOR, recipient, amount, txSender);
 }
 
-const confirm = (txId: number, executor: any, txSender: string) => {
+const confirm = (CHAIN: Chain, txId: number, executor: any, txSender: string) => {
     return CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -67,7 +64,7 @@ const confirm = (txId: number, executor: any, txSender: string) => {
     ]).receipts[0].result;
 }
 
-const revoke = (txId: number, txSender: string) => {
+const revoke = (CHAIN: Chain, txId: number, txSender: string) => {
     return CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
@@ -78,487 +75,460 @@ const revoke = (txId: number, txSender: string) => {
     ]).receipts[0].result;
 }
 
-const getOwners = () => {
+const getOwners = (CHAIN: Chain, txSender: string) => {
     let block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
             "get-owners",
             [],
-            WALLETS[0]
+            txSender
         ),
     ]);
 
     return block.receipts[0].result.expectList();
 }
 
-const getNonce = () => {
+const getNonce = (CHAIN: Chain, txSender: string) => {
     const block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
             "get-nonce",
             [],
-            WALLETS[0]
+            txSender
         ),
     ]);
 
     return block.receipts[0].result;
 }
 
-const getThreshold = () => {
+const getThreshold = (CHAIN: Chain, txSender: string) => {
     const block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
             "get-threshold",
             [],
-            WALLETS[0]
+            txSender
         ),
     ]);
     return block.receipts[0].result;
 }
 
-const getTransaction = (txId: number) => {
+const getTransaction = (CHAIN: Chain, txId: number, txSender: string) => {
     const block = CHAIN.mineBlock([
         Tx.contractCall(
             "safe",
             "get-transaction",
             [types.uint(txId)],
-            WALLETS[0]
+            txSender
         ),
     ]);
 
     return block.receipts[0].result.expectTuple()
 }
 
+
+/* Test definitions */
+
+type TestFn = (
+    CHAIN: Chain,
+    WALLETS: string[],
+    DEPLOYER: string,
+) => void
+
+const testSetup: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // send some stx to the safe contract
+    CHAIN.mineBlock([
+        Tx.transferSTX(
+            50000000,
+            "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe",
+            "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+        ),
+    ]);
+
+    const assetMap = CHAIN.getAssetsMaps();
+    assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 50000000);
+}
+
+const testSafeOnly: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    let block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "add-owner",
+            [types.principal(WALLETS[3])],
+            WALLETS[0]
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectErr(), "u100");
+
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "remove-owner",
+            [types.principal(WALLETS[2])],
+            WALLETS[1]
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectErr(), "u100");
+
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "set-threshold",
+            [types.uint(1)],
+            WALLETS[2]
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectErr(), "u100");
+}
+
+const testOnlyOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    let resp = addOwner(CHAIN, "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND", WALLETS[3]);
+    assertEquals(resp.expectErr(), "u130");
+
+    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[3]);
+    assertEquals(resp.expectErr(), "u130");
+}
+
+const testAddNewOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Check current owners. Should be 3.
+    let owners = getOwners(CHAIN, WALLETS[0]);
+    assertEquals(owners.length, 3);
+    assertEquals(owners[0], WALLETS[0]);
+    assertEquals(owners[1], WALLETS[1]);
+    assertEquals(owners[2], WALLETS[2]);
+
+    // Start a new transaction to add a new owner.
+    let resp = addOwner(CHAIN, WALLETS[3], WALLETS[0]);
+    assertEquals(resp.expectOk(), "u0");
+
+    // The new transaction should be available in the transacions mapping.
+    let tx: any = getTransaction(CHAIN, 0, WALLETS[0]);
+    let confirmations = tx.confirmations.expectList()
+
+    assertEquals(tx.id, "u0");
+    assertEquals(tx.confirmed, "false");
+    assertEquals(confirmations.length, 1);
+    assertEquals(confirmations[0], WALLETS[0]);
+
+    // The user already confirmed transaction by submitting it. Should revert.
+    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[0]);
+    assertEquals(resp.expectErr(), "u150");
+
+    // Executor should be passed properly. Should revert.
+    resp = confirm(CHAIN, 0, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
+    assertEquals(resp.expectErr(), "u160");
+
+    // Owner 2 confirms.
+    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[1]);
+    assertEquals(resp.expectOk(), "true");
+
+    // The transaction already confirmed. Should revert
+    resp = confirm(CHAIN, 0, ADD_OWNER_EXECUTOR, WALLETS[2]);
+    assertEquals(resp.expectErr(), "u180");
+
+    // The transaction confirmed by sufficient number of owners.
+    tx = getTransaction(CHAIN, 0, WALLETS[0]);
+    confirmations = tx.confirmations.expectList();
+
+    assertEquals(tx.confirmed, "true");
+    assertEquals(confirmations.length, 2);
+    assertEquals(confirmations[0], WALLETS[0]);
+    assertEquals(confirmations[1], WALLETS[1]);
+
+    // New owner should be added. should be 4.
+    owners = getOwners(CHAIN, WALLETS[0]);
+    assertEquals(owners.length, 4);
+    assertEquals(owners[3], WALLETS[3]);
+
+    // Nonce should be incremented.
+    const nonce = getNonce(CHAIN, WALLETS[0]);
+    assertEquals(nonce, "u1");
+}
+
+const testSetThreshold: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Check current value. should be 2.
+    let threshold = getThreshold(CHAIN, WALLETS[0]);
+    assertEquals(threshold, "u2");
+
+    // Start a transaction to update minimum confirmation requirement.
+    let resp = setThreshold(CHAIN, 3, WALLETS[0]);
+    assertEquals(resp.expectOk(), "u1");
+
+    // // Owner 2 confirms. Confirmed.
+    resp = confirm(CHAIN, 1, THRESHOLD_EXECUTOR, WALLETS[1]);
+    assertEquals(resp.expectOk(), "true");
+
+    // Minimum confirmation requirement should be updated as 3.
+    threshold = getThreshold(CHAIN, WALLETS[0]);
+    assertEquals(threshold, "u3");
+}
+
+const testRemoveOwner: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Start a new transaction to remove an owner.
+    let resp = removeOwner(CHAIN, WALLETS[0], WALLETS[3]);
+    assertEquals(resp.expectOk(), "u2");
+
+    // Owner 2 confirms.
+    resp = confirm(CHAIN, 2, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
+    assertEquals(resp.expectOk(), "false");
+
+    // Owner 3 confirms.
+    resp = confirm(CHAIN, 2, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
+    assertEquals(resp.expectOk(), "true");
+
+    // Confirmed.
+    let tx: any = getTransaction(CHAIN, 2, WALLETS[0]);
+    let confirmations = tx.confirmations.expectList()
+
+    assertEquals(tx.confirmed, "true");
+    assertEquals(confirmations.length, 3);
+    assertEquals(confirmations[0], WALLETS[3]);
+    assertEquals(confirmations[1], WALLETS[1]);
+    assertEquals(confirmations[2], WALLETS[2]);
+
+    // Owner should be removed. Now we should have 3 owners.
+    let owners = getOwners(CHAIN, WALLETS[0]);
+    assertEquals(owners.length, 3);
+}
+
+const testSpendStx: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Start a new transaction to send STX from the safe to another account
+    let resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
+    assertEquals(resp.expectOk(), "u3");
+
+    // Owner 2 confirms.
+    resp = confirm(CHAIN, 3, TRANSFER_STX_EXECUTOR, WALLETS[2]);
+    assertEquals(resp.expectOk(), "false");
+
+    // Owner 3 confirms.
+    resp = confirm(CHAIN, 3, TRANSFER_STX_EXECUTOR, WALLETS[3]);
+    assertEquals(resp.expectOk(), "true");
+
+    // Confirmed. STX balance of the safe should be 0.
+    const assetMap = CHAIN.getAssetsMaps();
+    assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 0);
+}
+
+const testVaultOwnershipExample: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // We have an imaginary vault contract and owner of the contract is the safe contract
+    // We want to update `token-per-cycle` by calling an owner only function `set-token-per-cycle`
+
+    // Default token per cycle is u100
+    let block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "vault",
+            "get-token-per-cycle",
+            [],
+            DEPLOYER
+        ),
+    ]);
+    assertEquals(block.receipts[0].result, "u100");
+
+    // The vault contract can't be updated directly by a user because it is owned by the safe contract
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "vault",
+            "set-token-per-cycle",
+            [types.uint(500)],
+            DEPLOYER
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectErr(), "u900");
+
+    // Start transaction to update `token-per-cycle`
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "submit",
+            [
+                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
+                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
+                FT_NONE,
+                NFT_NONE,
+                types.some(types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")),
+                types.some(types.uint(1200)),
+                types.none()
+            ],
+            WALLETS[1]
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectOk(), "u4");
+
+    // Owner 2 confirms.
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "confirm",
+            [
+                types.uint(4),
+                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
+                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
+                FT_NONE,
+                NFT_NONE,
+            ],
+            WALLETS[2]
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectOk(), "false");
+
+    //  Owner 3 confirms.
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "confirm",
+            [
+                types.uint(4),
+                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
+                types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
+                FT_NONE,
+                NFT_NONE,
+            ],
+            WALLETS[3]
+        ),
+    ]);
+    assertEquals(block.receipts[0].result.expectOk(), "true");
+
+    // `token-per-cycle` should be updated
+    block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "vault",
+            "get-token-per-cycle",
+            [],
+            DEPLOYER
+        ),
+    ]);
+    assertEquals(block.receipts[0].result, "u1200");
+}
+
+const testListTransactionsByIds: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    let block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "get-transactions",
+            [types.list([types.uint(0), types.uint(1), types.uint(2), types.uint(3), types.uint(4)])],
+            WALLETS[0]
+        ),
+    ]);
+
+    assertEquals(block.receipts[0].result.expectList().length, 5);
+}
+
+const testGetVersion: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    let block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "get-version",
+            [],
+            WALLETS[0]
+        ),
+    ]);
+
+    assertEquals(block.receipts[0].result, '"0.0.2.alpha"');
+}
+
+const testGetInfo: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    let block = CHAIN.mineBlock([
+        Tx.contractCall(
+            "safe",
+            "get-info",
+            [],
+            WALLETS[0]
+        ),
+    ]);
+
+    const json = JSON.parse(JSON.stringify(block.receipts[0].result.expectTuple()));
+    assertEquals(json.version !== undefined, true);
+    assertEquals(json.owners !== undefined, true);
+    assertEquals(json["threshold"] !== undefined, true);
+    assertEquals(json.nonce !== undefined, true);
+}
+
+const testRevoke: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Tx not exists.
+    let resp = revoke(CHAIN, 10, WALLETS[2]);
+    assertEquals(resp.expectErr(), 'u140');
+
+    // Tx already confirmed.
+    resp = revoke(CHAIN, 4, WALLETS[2]);
+    assertEquals(resp.expectErr(), 'u180');
+
+    // Start a new tx.
+    resp = transferStx(CHAIN, "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
+    assertEquals(resp.expectOk(), "u5");
+
+    // Should reject becuase the owner hasn't confirmed the tx.
+    resp = revoke(CHAIN, 5, WALLETS[2]);
+    assertEquals(resp.expectErr(), 'u190');
+
+    // Should revoke.
+    resp = revoke(CHAIN, 5, WALLETS[1]);
+    assertEquals(resp.expectOk(), 'true');
+
+    // Confirmation should be removed.
+    const tx = getTransaction(CHAIN, 5, WALLETS[0]);
+    assertEquals(JSON.parse(JSON.stringify(tx)).confirmations, '[]');
+}
+
+const testSetThresholdOverflowProtection: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Start a transaction to set threshold.
+    let resp = setThreshold(CHAIN, 21, WALLETS[1]);
+    assertEquals(resp.expectOk(), "u6");
+
+    // Owner 2 confirms.
+    resp = confirm(CHAIN, 6, THRESHOLD_EXECUTOR, WALLETS[2]);
+
+    // Owner 3 confirms but reverted.
+    resp = confirm(CHAIN, 6, THRESHOLD_EXECUTOR, WALLETS[3]);
+    assertEquals(resp.expectErr(), "u220");
+}
+
+const testSetThresholdOwnerCountProtection: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Start a transaction to set threshold.
+    let resp = setThreshold(CHAIN, 4, WALLETS[1]);
+    assertEquals(resp.expectOk(), "u7");
+
+    // Owner 2 confirms.
+    resp = confirm(CHAIN, 7, THRESHOLD_EXECUTOR, WALLETS[2]);
+
+    // Owner 3 confirms but reverted.
+    resp = confirm(CHAIN, 7, THRESHOLD_EXECUTOR, WALLETS[3]);
+    assertEquals(resp.expectErr(), "u230");
+}
+
+const testRemoveOwnerThresholdProtection: TestFn = (CHAIN: Chain, WALLETS: string[], DEPLOYER: string) => {
+    // Start a new transaction to remove an owner.
+    let resp = removeOwner(CHAIN, WALLETS[3], WALLETS[3]);
+    assertEquals(resp.expectOk(), "u8");
+
+    // Owner 2 confirms.
+    resp = confirm(CHAIN, 8, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
+    assertEquals(resp.expectOk(), "false");
+
+    // Owner 3 confirms but reverted.
+    resp = confirm(CHAIN, 8, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
+    assertEquals(resp.expectErr(), "u230");
+}
+
 Clarinet.test({
-    name: "Setup",
+    name: "MultiSafe Tests",
     async fn(chain: Chain, accounts: Map<string, Account>) {
-        CHAIN = chain;
-        WALLETS = [...Array(9).keys()].map(x => accounts.get(`wallet_${x + 1}`)!.address);
-        DEPLOYER = accounts.get('deployer')!.address
-
-        // send some stx to the safe contract
-        CHAIN.mineBlock([
-            Tx.transferSTX(
-                50000000,
-                "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe",
-                "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
-            ),
-        ]);
-
-        const assetMap = CHAIN.getAssetsMaps();
-        assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 50000000);
-    },
-});
-
-
-Clarinet.test({
-    name: "Safe only checks",
-    async fn() {
-        let block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "add-owner",
-                [types.principal(WALLETS[3])],
-                WALLETS[0]
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectErr(), "u100");
-
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "remove-owner",
-                [types.principal(WALLETS[2])],
-                WALLETS[1]
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectErr(), "u100");
-
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "set-threshold",
-                [types.uint(1)],
-                WALLETS[2]
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectErr(), "u100");
-    },
-});
-
-
-Clarinet.test({
-    name: "Onwer only checks",
-    async fn() {
-        let resp = addOwner("ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND", WALLETS[3]);
-        assertEquals(resp.expectErr(), "u130");
-
-        resp = confirm(0, ADD_OWNER_EXECUTOR, WALLETS[3]);
-        assertEquals(resp.expectErr(), "u130");
-    },
-});
-
-
-Clarinet.test({
-    name: "Add a new owner",
-    async fn() {
-        // Check current owners. Should be 3.
-        let owners = getOwners();
-        assertEquals(owners.length, 3);
-        assertEquals(owners[0], WALLETS[0]);
-        assertEquals(owners[1], WALLETS[1]);
-        assertEquals(owners[2], WALLETS[2]);
-
-        // Start a new transaction to add a new owner.
-        let resp = addOwner(WALLETS[3], WALLETS[0]);
-        assertEquals(resp.expectOk(), "u0");
-
-        // The new transaction should be available in the transacions mapping.
-        let tx: any = getTransaction(0);
-        let confirmations = tx.confirmations.expectList()
-
-        assertEquals(tx.id, "u0");
-        assertEquals(tx.confirmed, "false");
-        assertEquals(confirmations.length, 1);
-        assertEquals(confirmations[0], WALLETS[0]);
-
-        // The user already confirmed transaction by submitting it. Should revert.
-        resp = confirm(0, ADD_OWNER_EXECUTOR, WALLETS[0]);
-        assertEquals(resp.expectErr(), "u150");
-
-        // Executor should be passed properly. Should revert.
-        resp = confirm(0, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
-        assertEquals(resp.expectErr(), "u160");
-
-        // Owner 2 confirms.
-        resp = confirm(0, ADD_OWNER_EXECUTOR, WALLETS[1]);
-        assertEquals(resp.expectOk(), "true");
-
-        // The transaction already confirmed. Should revert
-        resp = confirm(0, ADD_OWNER_EXECUTOR, WALLETS[2]);
-        assertEquals(resp.expectErr(), "u180");
-
-        // The transaction confirmed by sufficient number of owners.
-        tx = getTransaction(0);
-        confirmations = tx.confirmations.expectList();
-
-        assertEquals(tx.confirmed, "true");
-        assertEquals(confirmations.length, 2);
-        assertEquals(confirmations[0], WALLETS[0]);
-        assertEquals(confirmations[1], WALLETS[1]);
-
-        // New owner should be added. should be 4.
-        owners = getOwners();
-        assertEquals(owners.length, 4);
-        assertEquals(owners[3], WALLETS[3]);
-
-        // Nonce should be incremented.
-        const nonce = getNonce();
-        assertEquals(nonce, "u1");
-    },
-});
-
-
-Clarinet.test({
-    name: "Set confirmation threshold",
-    async fn() {
-        // Check current value. should be 2.
-        let threshold = getThreshold();
-        assertEquals(threshold, "u2");
-
-        // Start a transaction to update minimum confirmation requirement.
-        let resp = setThreshold(3, WALLETS[0]);
-        assertEquals(resp.expectOk(), "u1");
-
-        // // Owner 2 confirms. Confirmed.
-        resp = confirm(1, THRESHOLD_EXECUTOR, WALLETS[1]);
-        assertEquals(resp.expectOk(), "true");
-
-        // Minimum confirmation requirement should be updated as 3.
-        threshold = getThreshold();
-        assertEquals(threshold, "u3");
-    },
-});
-
-
-Clarinet.test({
-    name: "Remove an owner",
-    async fn() {
-        // Start a new transaction to remove an owner.
-        let resp = removeOwner(WALLETS[0], WALLETS[3]);
-        assertEquals(resp.expectOk(), "u2");
-
-        // Owner 2 confirms.
-        resp = confirm(2, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
-        assertEquals(resp.expectOk(), "false");
-
-        // Owner 3 confirms.
-        resp = confirm(2, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
-        assertEquals(resp.expectOk(), "true");
-
-        // Confirmed.
-        let tx: any = getTransaction(2);
-        let confirmations = tx.confirmations.expectList()
-
-        assertEquals(tx.confirmed, "true");
-        assertEquals(confirmations.length, 3);
-        assertEquals(confirmations[0], WALLETS[3]);
-        assertEquals(confirmations[1], WALLETS[1]);
-        assertEquals(confirmations[2], WALLETS[2]);
-
-        // Owner should be removed. Now we should have 3 owners.
-        let owners = getOwners();
-        assertEquals(owners.length, 3);
-    },
-});
-
-
-Clarinet.test({
-    name: "Spend STX",
-    async fn() {
-        // Start a new transaction to send STX from the safe to another account
-        let resp = transferStx("STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
-        assertEquals(resp.expectOk(), "u3");
-
-        // Owner 2 confirms.
-        resp = confirm(3, TRANSFER_STX_EXECUTOR, WALLETS[2]);
-        assertEquals(resp.expectOk(), "false");
-
-        // Owner 3 confirms.
-        resp = confirm(3, TRANSFER_STX_EXECUTOR, WALLETS[3]);
-        assertEquals(resp.expectOk(), "true");
-
-        // Confirmed. STX balance of the safe should be 0.
-        const assetMap = CHAIN.getAssetsMaps();
-        assertEquals(assetMap["assets"]["STX"]["ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"], 0);
-    },
-});
-
-
-Clarinet.test({
-    name: "A vault ownership exmaple",
-    async fn() {
-
-        // We have an imaginary vault contract and owner of the contract is the safe contract
-        // We want to update `token-per-cycle` by calling an owner only function `set-token-per-cycle`
-
-        // Default token per cycle is u100
-        let block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "vault",
-                "get-token-per-cycle",
-                [],
-                DEPLOYER
-            ),
-        ]);
-        assertEquals(block.receipts[0].result, "u100");
-
-        // The vault contract can't be updated directly by a user because it is owned by the safe contract
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "vault",
-                "set-token-per-cycle",
-                [types.uint(500)],
-                DEPLOYER
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectErr(), "u900");
-
-        // Start transaction to update `token-per-cycle`
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "submit",
-                [
-                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
-                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
-                    FT_NONE,
-                    NFT_NONE,
-                    types.some(types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")),
-                    types.some(types.uint(1200)),
-                    types.none()
-                ],
-                WALLETS[1]
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectOk(), "u4");
-
-        // Owner 2 confirms.
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "confirm",
-                [
-                    types.uint(4),
-                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
-                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
-                    FT_NONE,
-                    NFT_NONE,
-                ],
-                WALLETS[2]
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectOk(), "false");
-
-        //  Owner 3 confirms.
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "confirm",
-                [
-                    types.uint(4),
-                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.set-vault-token-per-cycle"),
-                    types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.safe"),
-                    FT_NONE,
-                    NFT_NONE,
-                ],
-                WALLETS[3]
-            ),
-        ]);
-        assertEquals(block.receipts[0].result.expectOk(), "true");
-
-        // `token-per-cycle` should be updated
-        block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "vault",
-                "get-token-per-cycle",
-                [],
-                DEPLOYER
-            ),
-        ]);
-        assertEquals(block.receipts[0].result, "u1200");
-    },
-});
-
-Clarinet.test({
-    name: "List transactions by ids",
-    async fn() {
-        let block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "get-transactions",
-                [types.list([types.uint(0), types.uint(1), types.uint(2), types.uint(3), types.uint(4)])],
-                WALLETS[0]
-            ),
-        ]);
-
-        assertEquals(block.receipts[0].result.expectList().length, 5);
-    },
-});
-
-Clarinet.test({
-    name: "Get version",
-    async fn() {
-        let block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "get-version",
-                [],
-                WALLETS[0]
-            ),
-        ]);
-
-        assertEquals(block.receipts[0].result, '"0.0.2.alpha"');
-    },
-});
-
-Clarinet.test({
-    name: "Get info",
-    async fn() {
-        let block = CHAIN.mineBlock([
-            Tx.contractCall(
-                "safe",
-                "get-info",
-                [],
-                WALLETS[0]
-            ),
-        ]);
-
-        const json = JSON.parse(JSON.stringify(block.receipts[0].result.expectTuple()));
-        assertEquals(json.version !== undefined, true);
-        assertEquals(json.owners !== undefined, true);
-        assertEquals(json["threshold"] !== undefined, true);
-        assertEquals(json.nonce !== undefined, true);
-    },
-});
-
-Clarinet.test({
-    name: "Revoke",
-    async fn() {
-
-        // Tx not exists.
-        let resp = revoke(10, WALLETS[2]);
-        assertEquals(resp.expectErr(), 'u140');
-
-        // Tx already confirmed.
-        resp = revoke(4, WALLETS[2]);
-        assertEquals(resp.expectErr(), 'u180');
-
-        // Start a new tx.
-        resp = transferStx("STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6", 50000000, WALLETS[1]);
-        assertEquals(resp.expectOk(), "u5");
-
-        // Should reject becuase the owner hasn't confirmed the tx.
-        resp = revoke(5, WALLETS[2]);
-        assertEquals(resp.expectErr(), 'u190');
-
-        // Should revoke.
-        resp = revoke(5, WALLETS[1]);
-        assertEquals(resp.expectOk(), 'true');
-
-        // Confirmation should be removed.
-        const tx = getTransaction(5);
-        assertEquals(JSON.parse(JSON.stringify(tx)).confirmations, '[]');
-    },
-});
-
-
-Clarinet.test({
-    name: "Set minimum confirmation - overflow protection test",
-    async fn() {
-        // Start a transaction to set threshold.
-        let resp = setThreshold(21, WALLETS[1]);
-        assertEquals(resp.expectOk(), "u6");
-
-        // Owner 2 confirms.
-        resp = confirm(6, THRESHOLD_EXECUTOR, WALLETS[2]);
-
-        // Owner 3 confirms but reverted.
-        resp = confirm(6, THRESHOLD_EXECUTOR, WALLETS[3]);
-        assertEquals(resp.expectErr(), "u220");
-    },
-});
-
-Clarinet.test({
-    name: "Set minimum confirmation - can't be higher than owner count",
-    async fn() {
-        // Start a transaction to set threshold.
-        let resp = setThreshold(4, WALLETS[1]);
-        assertEquals(resp.expectOk(), "u7");
-
-        // Owner 2 confirms.
-        resp = confirm(7, THRESHOLD_EXECUTOR, WALLETS[2]);
-
-        // Owner 3 confirms but reverted.
-        resp = confirm(7, THRESHOLD_EXECUTOR, WALLETS[3]);
-        assertEquals(resp.expectErr(), "u230");
-    },
-});
-
-
-Clarinet.test({
-    name: "Remove an owner - owner count cannot be lower than threshold",
-    async fn() {
-        // Start a new transaction to remove an owner.
-        let resp = removeOwner(WALLETS[3], WALLETS[3]);
-        assertEquals(resp.expectOk(), "u8");
-
-        // Owner 2 confirms.
-        resp = confirm(8, REMOVE_OWNER_EXECUTOR, WALLETS[1]);
-        assertEquals(resp.expectOk(), "false");
-
-        // Owner 3 confirms but reverted.
-        resp = confirm(8, REMOVE_OWNER_EXECUTOR, WALLETS[2]);
-        assertEquals(resp.expectErr(), "u230");
+        const WALLETS = [...Array(9).keys()].map(x => accounts.get(`wallet_${x + 1}`)!.address);
+        const DEPLOYER = accounts.get('deployer')!.address
+
+        testSetup(chain, WALLETS, DEPLOYER);
+        testSafeOnly(chain, WALLETS, DEPLOYER);
+        testOnlyOwner(chain, WALLETS, DEPLOYER);
+        testAddNewOwner(chain, WALLETS, DEPLOYER);
+        testSetThreshold(chain, WALLETS, DEPLOYER);
+        testRemoveOwner(chain, WALLETS, DEPLOYER);
+        testSpendStx(chain, WALLETS, DEPLOYER);
+        testVaultOwnershipExample(chain, WALLETS, DEPLOYER);
+        testListTransactionsByIds(chain, WALLETS, DEPLOYER);
+        testGetVersion(chain, WALLETS, DEPLOYER);
+        testGetInfo(chain, WALLETS, DEPLOYER);
+        testRevoke(chain, WALLETS, DEPLOYER);
+        testSetThresholdOverflowProtection(chain, WALLETS, DEPLOYER);
+        testSetThresholdOwnerCountProtection(chain, WALLETS, DEPLOYER);
+        testRemoveOwnerThresholdProtection(chain, WALLETS, DEPLOYER);
     },
 });


### PR DESCRIPTION
This PR contains testing improvements for clarinet 0.31.1. Now we have a new test runner implemented in order to run tests in a single chain session since clarinet 0.3x terminates session after each test `Clarinet.test` call. 