### PR TITLE
Fix for audit finding CR-01

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -57,6 +57,10 @@ depends_on = []
 path = "contracts/misc/magic-bridge.clar"
 depends_on = []
 
+[contracts.magic-bridge-fake]
+path = "contracts/misc/magic-bridge-fake.clar"
+depends_on = []
+
 [contracts.vault]
 path = "contracts/misc/vault.clar"
 depends_on = []

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -41,6 +41,10 @@ depends_on = ["safe"]
 path = "contracts/executors/magic-bridge-send.clar"
 depends_on = ["safe"]
 
+[contracts.magic-bridge-set]
+path = "contracts/executors/magic-bridge-set.clar"
+depends_on = ["safe"]
+
 [contracts.ft-none]
 path = "contracts/helper/ft-none.clar"
 depends_on = []

--- a/contracts/executors/magic-bridge-set.clar
+++ b/contracts/executors/magic-bridge-set.clar
@@ -1,0 +1,11 @@
+;; Title: Magic Bridge contract address updater
+;; Author: Talha Bugra Bulut & Trust Machines
+
+(impl-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.traits.executor-trait)
+(use-trait safe-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.traits.safe-trait)
+(use-trait nft-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.traits.sip-009-trait)
+(use-trait ft-trait 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.traits.sip-010-trait)
+
+(define-public (execute (safe <safe-trait>) (param-ft <ft-trait>) (param-nft <nft-trait>) (param-p (optional principal)) (param-u (optional uint)) (param-b (optional (buff 20))))
+		(contract-call? safe set-mb-address (unwrap! param-p (err u9999)))
+) 

--- a/contracts/misc/magic-bridge-fake.clar
+++ b/contracts/misc/magic-bridge-fake.clar
@@ -1,0 +1,41 @@
+(impl-trait .traits.magic-bridge-trait)
+
+(define-public (initialize-swapper)
+    (begin 
+        (asserts! (is-eq true true) (err u100))
+        (ok u1)
+    )
+)
+
+(define-public (escrow-swap 
+    (block { header: (buff 80), height: uint })
+    (prev-blocks (list 10 (buff 80)))
+    (tx (buff 1024))
+    (proof { tx-index: uint, hashes: (list 12 (buff 32)), tree-depth: uint })
+    (output-index uint)
+    (sender (buff 33))
+    (recipient (buff 33))
+    (expiration-buff (buff 4))
+    (hash (buff 32))
+    (swapper-buff (buff 4))
+    (supplier-id uint)
+    (min-to-receive uint)
+  )
+    (begin 
+        (asserts! (is-eq true true) (err u100))
+        (ok {
+     	sender-public-key: 0x21133213,
+		output-index: u1,
+		csv: u2,
+		redeem-script: 0x21133213,
+		sats: u100
+      })
+    )
+)
+
+(define-public (initiate-outbound-swap (xbtc uint) (btc-version (buff 1)) (btc-hash (buff 20)) (supplier-id uint))
+    (begin 
+        (asserts! (is-eq true true) (err u100))
+        (ok u1)
+    )
+)

--- a/contracts/traits.clar
+++ b/contracts/traits.clar
@@ -6,6 +6,7 @@
 		(add-owner (principal) (response bool uint))
 		(remove-owner (principal) (response bool uint))
 		(set-threshold (uint) (response bool uint))
+		(set-mb-address (principal) (response bool uint))
 	)
 )
 

--- a/tests/safe_test.ts
+++ b/tests/safe_test.ts
@@ -11,6 +11,7 @@ const THRESHOLD_EXECUTOR = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRT
 const TRANSFER_STX_EXECUTOR = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.transfer-stx");
 const MAGIC_BRIDGE_SET_EXECUTOR = types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.magic-bridge-set");
 const MAGIC_BRIDGE = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.magic-bridge";
+const MAGIC_BRIDGE_FAKE = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.magic-bridge-fake";
 
 /* Test helpers */
 
@@ -579,6 +580,32 @@ const TESTS: Record<string, TestFn> = {
             ),
         ]);
         assertEquals(block.receipts[0].result.expectErr(), "u130");
+
+        // Invalid magic bridge address passed. Should revert with ERR-INVALID-MB-ADDRESS
+        block = CHAIN.mineBlock([
+            Tx.contractCall(
+                "safe",
+                "mb-escrow-swap",
+                [
+                    types.principal(MAGIC_BRIDGE_FAKE),
+                    types.tuple({header: types.buff("0x21133213"), height: types.uint(1)}),
+                    types.list([]),
+                    types.buff("0x21133213"),
+                    types.tuple({ "tx-index": types.uint(1), hashes: types.list([]), "tree-depth": types.uint(1) }),
+                    types.uint(1),
+                    types.buff("0x21133213"),
+                    types.buff("0x21133213"),
+                    types.buff("0x21"),
+                    types.buff("0x21133213"),
+                    types.buff("0x21"),
+                    types.uint(1),
+                    types.uint(1)
+
+                ],
+                WALLETS[6]
+            ),
+        ]);
+        assertEquals(block.receipts[0].result.expectErr(), "u270");
     }
 }
 


### PR DESCRIPTION
A new data-var "mb-address" for validation at "mb-initialize-swapper" and "mb-escrow-swap"  along with getter and setter functions. 

A new executor "magic-bridge-set" to be able to update new "mb-address" data-var with owner votes.

magic-bridge-fake.clar is only for test purpose. We won't deploy it to chain.